### PR TITLE
Updated Ubuntu/Debian installation instructions

### DIFF
--- a/text/s0-c02-installing.textile
+++ b/text/s0-c02-installing.textile
@@ -18,7 +18,7 @@ $ sudo make prefix=/usr install install-doc install-info
 
 If you are running Ubuntu or another Debian based system, you can run
 
-shell. $ apt-get git-core
+shell. $ apt-get install git
 
 or on yum based systems, you can often run:
 


### PR DESCRIPTION
The "git-core" package has been renamed to "git", and is considered obsolete.
Also, there was a missing "install" command for apt-get.
