### PR TITLE
Fix typos

### DIFF
--- a/code/git-log-oneline.txt
+++ b/code/git-log-oneline.txt
@@ -1,5 +1,5 @@
 $ git log --pretty=oneline
 cf25cc3bfb0ece7dc3609b8dc0c committing all changes
-0c8a9ec46029a4e92a428cb98c9 changed the verison number
+0c8a9ec46029a4e92a428cb98c9 changed the version number
 0576fac355dd17e39fd2671b010 my second commit, which is..
 a11bef06a3f659402fe7563abf9 first commit

--- a/code/git-log.txt
+++ b/code/git-log.txt
@@ -9,7 +9,7 @@ commit 0c8a9ec46029a4e92a428cb98c9693f09f69a3ff
 Author: Scott Chacon <schacon@gmail.com>
 Date:   Mon Mar 17 21:52:11 2008 -0700
 
-    changed the verison number
+    changed the version number
 
 commit 0576fac355dd17e39fd2671b010e36299f713b4d
 Author: Scott Chacon <schacon@gmail.com>

--- a/code/git-show-commit.txt
+++ b/code/git-show-commit.txt
@@ -3,7 +3,7 @@ commit 0c8a9ec46029a4e92a428cb98c9693f09f69a3ff
 Author: Scott Chacon <schacon@gmail.com>
 Date:   Mon Mar 17 21:52:11 2008 -0700
 
-    changed the verison number
+    changed the version number
 
 diff --git a/Rakefile b/Rakefile
 index a874b73..8f94139 100644

--- a/text/s1-c07-treeish.textile
+++ b/text/s1-c07-treeish.textile
@@ -37,7 +37,7 @@ code. master@{5}
 
 This indicates the 5th prior value of the master branch.  Like the _Date Spec_, this depends on special files in the _.git/log_ directory that are written during commits, and is specific to _your_ repository.
 
-h4. Carrot Parent
+h4. Caret Parent
 
 code. e65s46^2
 master^2
@@ -48,7 +48,7 @@ h4. Tilde Spec
 
 code. e65s46~5 
 
-The tilde character, followed by a number, refers to the Nth generation grandparent of that commit.  To clarify from the carrot, this is the equivalent commit in caret syntax:
+The tilde character, followed by a number, refers to the Nth generation grandparent of that commit.  To clarify from the caret, this is the equivalent commit in caret syntax:
 
 code. e65s46^^^^^
 

--- a/text/s2-c05-browsing-git.textile
+++ b/text/s2-c05-browsing-git.textile
@@ -66,6 +66,6 @@ For a more long term web interface to your repository, you can put the gitweb Pe
 
 * "git show":http://www.kernel.org/pub/software/scm/git/docs/git-show.html
 * "git ls-tree":http://www.kernel.org/pub/software/scm/git/docs/git-ls-tree.html
-* "git cat-file":http://www.kernel.org/pub/software/scm/git/docs/git-cat-fileß.html
+* "git cat-file":http://www.kernel.org/pub/software/scm/git/docs/git-cat-file.html
 * "gitk":http://www.kernel.org/pub/software/scm/git/docs/gitk.html
 * "git instaweb":http://www.kernel.org/pub/software/scm/git/docs/git-instaweb.html

--- a/text/s2-c08-simple-merging.textile
+++ b/text/s2-c08-simple-merging.textile
@@ -21,7 +21,7 @@ Let's say that we created a @versioning@ branch and then modified the version in
 
 shell. merge-conflict.txt
 
-It tells us that there was a conflict and so the new commit object was not created.  We will have to merge the conflicted file manually and then commit it again.  The output tells us the files that had conflicts, in this case it was the @Rakefile@.
+It tells us that there was a conflict and so the new commit object was not created.  We will have to merge the conflicted file manually and then commit it again.  The output tells us the files that had conflicts; in this case it was the @Rakefile@.
 
 ruby. rakefile.rb
 


### PR DESCRIPTION
Fix a few trivial typos that I noticed when reading the PDF.

The first patch, fixing the spelling error "verison" -> "version" in a commit message, would of course also alter the SHA-1s of the commits in the example.  But it doesn't look like there is any intention that the reader could replicate the SHA-1s, so I don't think it is a problem that the SHA-1 shown could not actually result from a commit with the log message in its corrected form.
